### PR TITLE
Fix some missed references to provider-template

### DIFF
--- a/apis/cloudflare.go
+++ b/apis/cloudflare.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package apis contains Kubernetes API for the Template provider.
+// Package apis contains Kubernetes API for the Cloudflare provider.
 package apis
 
 import (

--- a/apis/spectrum/v1alpha1/doc.go
+++ b/apis/spectrum/v1alpha1/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains the v1alpha1 group Spectrum resources of the Template provider.
+// Package v1alpha1 contains the v1alpha1 group Spectrum resources of the Cloudflare provider.
 // +kubebuilder:object:generate=true
 // +groupName=spectrum.cloudflare.crossplane.io
 // +versionName=v1alpha1

--- a/apis/sslsaas/v1alpha1/doc.go
+++ b/apis/sslsaas/v1alpha1/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains the v1alpha1 group SSL SaaS resources of the Template provider.
+// Package v1alpha1 contains the v1alpha1 group SSL SaaS resources of the Cloudflare provider.
 // +kubebuilder:object:generate=true
 // +groupName=sslsaas.cloudflare.crossplane.io
 // +versionName=v1alpha1

--- a/apis/v1alpha1/doc.go
+++ b/apis/v1alpha1/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains the core resources of the Template provider.
+// Package v1alpha1 contains the core resources of the Cloudflare provider.
 // +kubebuilder:object:generate=true
 // +groupName=cloudflare.crossplane.io
 // +versionName=v1alpha1

--- a/apis/v1alpha1/types.go
+++ b/apis/v1alpha1/types.go
@@ -44,7 +44,7 @@ type ProviderConfigStatus struct {
 
 // +kubebuilder:object:root=true
 
-// A ProviderConfig configures a Template provider.
+// A ProviderConfig configures a Cloudflare provider.
 // +kubebuilder:subresource:status
 // +kubebuilder:printcolumn:name="AGE",type="date",JSONPath=".metadata.creationTimestamp"
 // +kubebuilder:printcolumn:name="SECRET-NAME",type="string",JSONPath=".spec.credentials.secretRef.name",priority=1

--- a/apis/zone/v1alpha1/doc.go
+++ b/apis/zone/v1alpha1/doc.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Package v1alpha1 contains the v1alpha1 group Zone resources of the Template provider.
+// Package v1alpha1 contains the v1alpha1 group Zone resources of the Cloudflare provider.
 // +kubebuilder:object:generate=true
 // +groupName=zone.cloudflare.crossplane.io
 // +versionName=v1alpha1

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -33,7 +33,7 @@ import (
 
 func main() {
 	var (
-		app            = kingpin.New(filepath.Base(os.Args[0]), "Template support for Crossplane.").DefaultEnvars()
+		app            = kingpin.New(filepath.Base(os.Args[0]), "Cloudflare support for Crossplane.").DefaultEnvars()
 		debug          = app.Flag("debug", "Run with debug logging.").Short('d').Bool()
 		syncPeriod     = app.Flag("sync", "Controller manager sync period such as 300ms, 1.5h, or 2h45m").Short('s').Default("1h").Duration()
 		leaderElection = app.Flag("leader-election", "Use leader election for the controller manager.").Short('l').Default("false").OverrideDefaultFromEnvar("LEADER_ELECTION").Bool()
@@ -62,7 +62,7 @@ func main() {
 	kingpin.FatalIfError(err, "Cannot create controller manager")
 
 	rl := ratelimiter.NewDefaultProviderRateLimiter(ratelimiter.DefaultProviderRPS)
-	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add Template APIs to scheme")
-	kingpin.FatalIfError(controller.Setup(mgr, log, rl), "Cannot setup Template controllers")
+	kingpin.FatalIfError(apis.AddToScheme(mgr.GetScheme()), "Cannot add Cloudflare APIs to scheme")
+	kingpin.FatalIfError(controller.Setup(mgr, log, rl), "Cannot setup Cloudflare controllers")
 	kingpin.FatalIfError(mgr.Start(ctrl.SetupSignalHandler()), "Cannot start controller manager")
 }

--- a/internal/controller/cloudflare.go
+++ b/internal/controller/cloudflare.go
@@ -33,7 +33,7 @@ import (
 	zone "github.com/benagricola/provider-cloudflare/internal/controller/zone"
 )
 
-// Setup creates all Template controllers with the supplied logger and adds them to
+// Setup creates all Cloudflare controllers with the supplied logger and adds them to
 // the supplied manager.
 func Setup(mgr ctrl.Manager, l logging.Logger, wl workqueue.RateLimiter) error {
 	for _, setup := range []func(ctrl.Manager, logging.Logger, workqueue.RateLimiter) error{

--- a/package/crds/cloudflare.crossplane.io_providerconfigs.yaml
+++ b/package/crds/cloudflare.crossplane.io_providerconfigs.yaml
@@ -29,7 +29,7 @@ spec:
     name: v1alpha1
     schema:
       openAPIV3Schema:
-        description: A ProviderConfig configures a Template provider.
+        description: A ProviderConfig configures a Cloudflare provider.
         properties:
           apiVersion:
             description: 'APIVersion defines the versioned schema of this representation


### PR DESCRIPTION
Looks like we missed some references to "Template" (of provider-template fame). This commit fixes those references
so that they correctly refer to Cloudflare.

These are all comment changes with the exception of fixing some of the messages reported by the provider when running.

Signed-off-by: Ben Agricola <bagricola@squiz.co.uk>