### PR TITLE
Rename module for repo move

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -38,7 +38,7 @@ linters-settings:
   goimports:
     # put imports beginning with prefix after 3rd-party packages;
     # it's a comma-separated list of prefixes
-    local-prefixes: github.com/benagricola/provider-cloudflare
+    local-prefixes: github.com/crossplane-contrib/provider-cloudflare
 
   gocyclo:
     # minimal code complexity to report, 30 by default (but we recommend 10-20)

--- a/apis/cloudflare.go
+++ b/apis/cloudflare.go
@@ -20,13 +20,13 @@ package apis
 import (
 	"k8s.io/apimachinery/pkg/runtime"
 
-	dnsv1alpha1 "github.com/benagricola/provider-cloudflare/apis/dns/v1alpha1"
-	firewallv1alpha1 "github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
-	spectrumv1alpha1 "github.com/benagricola/provider-cloudflare/apis/spectrum/v1alpha1"
-	sslsaasv1alpha1 "github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
-	cloudflarev1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	workersv1alpha1 "github.com/benagricola/provider-cloudflare/apis/workers/v1alpha1"
-	zonev1alpha1 "github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	dnsv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/dns/v1alpha1"
+	firewallv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
+	spectrumv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/spectrum/v1alpha1"
+	sslsaasv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
+	cloudflarev1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	workersv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/workers/v1alpha1"
+	zonev1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 )
 
 func init() {

--- a/apis/dns/v1alpha1/types.go
+++ b/apis/dns/v1alpha1/types.go
@@ -27,7 +27,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 	"github.com/pkg/errors"
 
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 )
 
 // RecordParameters are the configurable fields of a DNS Record.

--- a/apis/firewall/v1alpha1/filter_types.go
+++ b/apis/firewall/v1alpha1/filter_types.go
@@ -25,7 +25,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
 
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 
 	"github.com/pkg/errors"
 )

--- a/apis/firewall/v1alpha1/rule_types.go
+++ b/apis/firewall/v1alpha1/rule_types.go
@@ -25,7 +25,7 @@ import (
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
 
-	zone "github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	zone "github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 
 	"github.com/pkg/errors"
 )

--- a/apis/spectrum/v1alpha1/types.go
+++ b/apis/spectrum/v1alpha1/types.go
@@ -25,7 +25,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 )
 
 // SpectrumApplicationDNS holds the external DNS configuration

--- a/apis/sslsaas/v1alpha1/custom_hostname.go
+++ b/apis/sslsaas/v1alpha1/custom_hostname.go
@@ -27,8 +27,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
 	"github.com/pkg/errors"
 
-	dns "github.com/benagricola/provider-cloudflare/apis/dns/v1alpha1"
-	zone "github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	dns "github.com/crossplane-contrib/provider-cloudflare/apis/dns/v1alpha1"
+	zone "github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 )
 
 // CustomHostnameSSLValidationErrors represents errors that occurred during SSL validation.

--- a/apis/sslsaas/v1alpha1/fallback_origin.go
+++ b/apis/sslsaas/v1alpha1/fallback_origin.go
@@ -22,8 +22,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	dns "github.com/benagricola/provider-cloudflare/apis/dns/v1alpha1"
-	zone "github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	dns "github.com/crossplane-contrib/provider-cloudflare/apis/dns/v1alpha1"
+	zone "github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 
 	xpv1 "github.com/crossplane/crossplane-runtime/apis/common/v1"
 	"github.com/crossplane/crossplane-runtime/pkg/reference"

--- a/apis/workers/v1alpha1/route.go
+++ b/apis/workers/v1alpha1/route.go
@@ -26,7 +26,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reference"
 	"github.com/pkg/errors"
 
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
 )
 
 // RouteParameters are the configurable fields of a DNS Route.

--- a/cmd/provider/main.go
+++ b/cmd/provider/main.go
@@ -27,8 +27,8 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 	"github.com/crossplane/crossplane-runtime/pkg/ratelimiter"
 
-	"github.com/benagricola/provider-cloudflare/apis"
-	"github.com/benagricola/provider-cloudflare/internal/controller"
+	"github.com/crossplane-contrib/provider-cloudflare/apis"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/controller"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/benagricola/provider-cloudflare
+module github.com/crossplane-contrib/provider-cloudflare
 
 go 1.13
 

--- a/internal/clients/applications/applications.go
+++ b/internal/clients/applications/applications.go
@@ -27,8 +27,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/benagricola/provider-cloudflare/apis/spectrum/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/spectrum/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/applications/applications_test.go
+++ b/internal/clients/applications/applications_test.go
@@ -29,8 +29,8 @@ import (
 
 	ptr "k8s.io/utils/pointer"
 
-	"github.com/benagricola/provider-cloudflare/apis/spectrum/v1alpha1"
-	"github.com/benagricola/provider-cloudflare/internal/clients/applications/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/spectrum/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/applications/fake"
 )
 
 func TestUpToDate(t *testing.T) {

--- a/internal/clients/cloudflare.go
+++ b/internal/clients/cloudflare.go
@@ -29,7 +29,7 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/benagricola/provider-cloudflare/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
 )
 
 const (

--- a/internal/clients/cloudflare_test.go
+++ b/internal/clients/cloudflare_test.go
@@ -40,7 +40,7 @@ import (
 	rtfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	v1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
+	v1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
 )
 
 func TestGetConfig(t *testing.T) {

--- a/internal/clients/firewall/filter/filter.go
+++ b/internal/clients/firewall/filter/filter.go
@@ -25,8 +25,8 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/firewall/filter/filter_test.go
+++ b/internal/clients/firewall/filter/filter_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
-	"github.com/benagricola/provider-cloudflare/internal/clients/firewall/filter/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/filter/fake"
 
 	"github.com/pkg/errors"
 

--- a/internal/clients/firewall/rule/rule.go
+++ b/internal/clients/firewall/rule/rule.go
@@ -27,8 +27,8 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/firewall/rule/rule_test.go
+++ b/internal/clients/firewall/rule/rule_test.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
-	"github.com/benagricola/provider-cloudflare/internal/clients/firewall/rule/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/rule/fake"
 
 	"github.com/pkg/errors"
 

--- a/internal/clients/records/records.go
+++ b/internal/clients/records/records.go
@@ -24,8 +24,8 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/benagricola/provider-cloudflare/apis/dns/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/dns/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/records/records_test.go
+++ b/internal/clients/records/records_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/benagricola/provider-cloudflare/apis/dns/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/dns/v1alpha1"
 
 	ptr "k8s.io/utils/pointer"
 )

--- a/internal/clients/sslsaas/customhostnames/custom_hostnames.go
+++ b/internal/clients/sslsaas/customhostnames/custom_hostnames.go
@@ -26,8 +26,8 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/sslsaas/customhostnames/custom_hostnames_test.go
+++ b/internal/clients/sslsaas/customhostnames/custom_hostnames_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
 
 	ptr "k8s.io/utils/pointer"
 )

--- a/internal/clients/sslsaas/fallbackorigins/fallback_origins.go
+++ b/internal/clients/sslsaas/fallbackorigins/fallback_origins.go
@@ -24,8 +24,8 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"github.com/pkg/errors"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/sslsaas/fallbackorigins/fallback_origins_test.go
+++ b/internal/clients/sslsaas/fallbackorigins/fallback_origins_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
 
 	ptr "k8s.io/utils/pointer"
 )

--- a/internal/clients/workers/route/route.go
+++ b/internal/clients/workers/route/route.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/workers/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/workers/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/workers/route/route_test.go
+++ b/internal/clients/workers/route/route_test.go
@@ -23,7 +23,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 
-	"github.com/benagricola/provider-cloudflare/apis/workers/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/workers/v1alpha1"
 
 	ptr "k8s.io/utils/pointer"
 )

--- a/internal/clients/zones/zone.go
+++ b/internal/clients/zones/zone.go
@@ -28,8 +28,8 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 const (

--- a/internal/clients/zones/zone_test.go
+++ b/internal/clients/zones/zone_test.go
@@ -29,8 +29,8 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
-	"github.com/benagricola/provider-cloudflare/internal/clients/zones/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/zones/fake"
 )
 
 func TestLateInitialize(t *testing.T) {

--- a/internal/controller/cloudflare.go
+++ b/internal/controller/cloudflare.go
@@ -22,15 +22,15 @@ import (
 
 	"github.com/crossplane/crossplane-runtime/pkg/logging"
 
-	"github.com/benagricola/provider-cloudflare/internal/controller/config"
-	record "github.com/benagricola/provider-cloudflare/internal/controller/dns"
-	filter "github.com/benagricola/provider-cloudflare/internal/controller/firewall/filter"
-	rule "github.com/benagricola/provider-cloudflare/internal/controller/firewall/rule"
-	application "github.com/benagricola/provider-cloudflare/internal/controller/spectrum"
-	customhostname "github.com/benagricola/provider-cloudflare/internal/controller/sslsaas/customhostname"
-	fallbackorigin "github.com/benagricola/provider-cloudflare/internal/controller/sslsaas/fallbackorigin"
-	route "github.com/benagricola/provider-cloudflare/internal/controller/workers/route"
-	zone "github.com/benagricola/provider-cloudflare/internal/controller/zone"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/controller/config"
+	record "github.com/crossplane-contrib/provider-cloudflare/internal/controller/dns"
+	filter "github.com/crossplane-contrib/provider-cloudflare/internal/controller/firewall/filter"
+	rule "github.com/crossplane-contrib/provider-cloudflare/internal/controller/firewall/rule"
+	application "github.com/crossplane-contrib/provider-cloudflare/internal/controller/spectrum"
+	customhostname "github.com/crossplane-contrib/provider-cloudflare/internal/controller/sslsaas/customhostname"
+	fallbackorigin "github.com/crossplane-contrib/provider-cloudflare/internal/controller/sslsaas/fallbackorigin"
+	route "github.com/crossplane-contrib/provider-cloudflare/internal/controller/workers/route"
+	zone "github.com/crossplane-contrib/provider-cloudflare/internal/controller/zone"
 )
 
 // Setup creates all Template controllers with the supplied logger and adds them to

--- a/internal/controller/config/config.go
+++ b/internal/controller/config/config.go
@@ -28,7 +28,7 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/providerconfig"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/benagricola/provider-cloudflare/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
 )
 
 // Setup adds a controller that reconciles ProviderConfigs by accounting for

--- a/internal/controller/dns/record.go
+++ b/internal/controller/dns/record.go
@@ -36,10 +36,10 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/dns/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	records "github.com/benagricola/provider-cloudflare/internal/clients/records"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/dns/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	records "github.com/crossplane-contrib/provider-cloudflare/internal/clients/records"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/dns/record_test.go
+++ b/internal/controller/dns/record_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/benagricola/provider-cloudflare/apis/dns/v1alpha1"
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	records "github.com/benagricola/provider-cloudflare/internal/clients/records"
-	"github.com/benagricola/provider-cloudflare/internal/clients/records/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/dns/v1alpha1"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	records "github.com/crossplane-contrib/provider-cloudflare/internal/clients/records"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/records/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/firewall/filter/filter.go
+++ b/internal/controller/firewall/filter/filter.go
@@ -34,10 +34,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	filter "github.com/benagricola/provider-cloudflare/internal/clients/firewall/filter"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	filter "github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/filter"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/firewall/filter/filter_test.go
+++ b/internal/controller/firewall/filter/filter_test.go
@@ -24,15 +24,15 @@ import (
 	"github.com/cloudflare/cloudflare-go"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/benagricola/provider-cloudflare/internal/clients/firewall/filter"
-	"github.com/benagricola/provider-cloudflare/internal/clients/firewall/filter/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/filter"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/filter/fake"
 
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -42,8 +42,8 @@ import (
 	rtfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	corev1 "k8s.io/api/core/v1"
 
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing

--- a/internal/controller/firewall/rule/rule.go
+++ b/internal/controller/firewall/rule/rule.go
@@ -34,10 +34,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	rule "github.com/benagricola/provider-cloudflare/internal/clients/firewall/rule"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	rule "github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/rule"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/firewall/rule/rule_test.go
+++ b/internal/controller/firewall/rule/rule_test.go
@@ -23,15 +23,15 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/firewall/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/firewall/v1alpha1"
 
 	"github.com/crossplane/crossplane-runtime/pkg/meta"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/benagricola/provider-cloudflare/internal/clients/firewall/rule"
-	"github.com/benagricola/provider-cloudflare/internal/clients/firewall/rule/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/rule"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/firewall/rule/fake"
 
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
@@ -44,8 +44,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	ptr "k8s.io/utils/pointer"
 
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing

--- a/internal/controller/spectrum/application.go
+++ b/internal/controller/spectrum/application.go
@@ -36,10 +36,10 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/spectrum/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	applications "github.com/benagricola/provider-cloudflare/internal/clients/applications"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/spectrum/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	applications "github.com/crossplane-contrib/provider-cloudflare/internal/clients/applications"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/spectrum/application_test.go
+++ b/internal/controller/spectrum/application_test.go
@@ -26,11 +26,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	"github.com/benagricola/provider-cloudflare/apis/spectrum/v1alpha1"
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	applications "github.com/benagricola/provider-cloudflare/internal/clients/applications"
-	"github.com/benagricola/provider-cloudflare/internal/clients/applications/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/spectrum/v1alpha1"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	applications "github.com/crossplane-contrib/provider-cloudflare/internal/clients/applications"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/applications/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	ptr "k8s.io/utils/pointer"

--- a/internal/controller/sslsaas/customhostname/custom_hostname.go
+++ b/internal/controller/sslsaas/customhostname/custom_hostname.go
@@ -34,10 +34,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	customhostnames "github.com/benagricola/provider-cloudflare/internal/clients/sslsaas/customhostnames"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	customhostnames "github.com/crossplane-contrib/provider-cloudflare/internal/clients/sslsaas/customhostnames"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/sslsaas/customhostname/custom_hostname_test.go
+++ b/internal/controller/sslsaas/customhostname/custom_hostname_test.go
@@ -36,11 +36,11 @@ import (
 	rtfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	customhostnames "github.com/benagricola/provider-cloudflare/internal/clients/sslsaas/customhostnames"
-	"github.com/benagricola/provider-cloudflare/internal/clients/sslsaas/customhostnames/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	customhostnames "github.com/crossplane-contrib/provider-cloudflare/internal/clients/sslsaas/customhostnames"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/sslsaas/customhostnames/fake"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing

--- a/internal/controller/sslsaas/fallbackorigin/fallback_origin.go
+++ b/internal/controller/sslsaas/fallbackorigin/fallback_origin.go
@@ -35,10 +35,10 @@ import (
 
 	"github.com/cloudflare/cloudflare-go"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	fallbackorigins "github.com/benagricola/provider-cloudflare/internal/clients/sslsaas/fallbackorigins"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	fallbackorigins "github.com/crossplane-contrib/provider-cloudflare/internal/clients/sslsaas/fallbackorigins"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/sslsaas/fallbackorigin/fallback_origin_test.go
+++ b/internal/controller/sslsaas/fallbackorigin/fallback_origin_test.go
@@ -34,11 +34,11 @@ import (
 	rtfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	"github.com/benagricola/provider-cloudflare/apis/sslsaas/v1alpha1"
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	fallbackorigins "github.com/benagricola/provider-cloudflare/internal/clients/sslsaas/fallbackorigins"
-	"github.com/benagricola/provider-cloudflare/internal/clients/sslsaas/fallbackorigins/fake"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/sslsaas/v1alpha1"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	fallbackorigins "github.com/crossplane-contrib/provider-cloudflare/internal/clients/sslsaas/fallbackorigins"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/sslsaas/fallbackorigins/fake"
 )
 
 // Unlike many Kubernetes projects Crossplane does not use third party testing

--- a/internal/controller/workers/route/route.go
+++ b/internal/controller/workers/route/route.go
@@ -35,10 +35,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/benagricola/provider-cloudflare/apis/workers/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	"github.com/benagricola/provider-cloudflare/internal/clients/workers/route"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/workers/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/workers/route"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/workers/route/route_test.go
+++ b/internal/controller/workers/route/route_test.go
@@ -25,11 +25,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/pkg/errors"
 
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	"github.com/benagricola/provider-cloudflare/apis/workers/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	routes "github.com/benagricola/provider-cloudflare/internal/clients/workers/route"
-	"github.com/benagricola/provider-cloudflare/internal/clients/workers/route/fake"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/workers/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	routes "github.com/crossplane-contrib/provider-cloudflare/internal/clients/workers/route"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/workers/route/fake"
 
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"

--- a/internal/controller/zone/zone.go
+++ b/internal/controller/zone/zone.go
@@ -36,10 +36,10 @@ import (
 	"github.com/crossplane/crossplane-runtime/pkg/reconciler/managed"
 	"github.com/crossplane/crossplane-runtime/pkg/resource"
 
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	zones "github.com/benagricola/provider-cloudflare/internal/clients/zones"
-	metrics "github.com/benagricola/provider-cloudflare/internal/metrics"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	zones "github.com/crossplane-contrib/provider-cloudflare/internal/clients/zones"
+	metrics "github.com/crossplane-contrib/provider-cloudflare/internal/metrics"
 )
 
 const (

--- a/internal/controller/zone/zone_test.go
+++ b/internal/controller/zone/zone_test.go
@@ -37,11 +37,11 @@ import (
 	rtfake "github.com/crossplane/crossplane-runtime/pkg/resource/fake"
 	"github.com/crossplane/crossplane-runtime/pkg/test"
 
-	pcv1alpha1 "github.com/benagricola/provider-cloudflare/apis/v1alpha1"
-	"github.com/benagricola/provider-cloudflare/apis/zone/v1alpha1"
-	clients "github.com/benagricola/provider-cloudflare/internal/clients"
-	zones "github.com/benagricola/provider-cloudflare/internal/clients/zones"
-	"github.com/benagricola/provider-cloudflare/internal/clients/zones/fake"
+	pcv1alpha1 "github.com/crossplane-contrib/provider-cloudflare/apis/v1alpha1"
+	"github.com/crossplane-contrib/provider-cloudflare/apis/zone/v1alpha1"
+	clients "github.com/crossplane-contrib/provider-cloudflare/internal/clients"
+	zones "github.com/crossplane-contrib/provider-cloudflare/internal/clients/zones"
+	"github.com/crossplane-contrib/provider-cloudflare/internal/clients/zones/fake"
 )
 
 type zoneModifier func(*v1alpha1.Zone)


### PR DESCRIPTION
Fixing up the module name now that the repo has been moved to `crossplane-contrib`.